### PR TITLE
Widescreen patch for Legacy of Kain: Soul Reaver SLUS-00708

### DIFF
--- a/patches/SLUS-00708.cht
+++ b/patches/SLUS-00708.cht
@@ -1,0 +1,13 @@
+# Legacy of Kain: Soul Reaver (USA)`
+[Widescreen 16:9]
+Type = Gameshark
+Activation = EndFrame
+OverrideAspectRatio = 16:9
+DisableWidescreenRendering = True
+Description = Patches the game to use 16:9 widescreen rendering, instead of 4:3.
+
+A703A374 10000C00
+A703A384 00340034
+A703A386 a7a0AFA0
+A703A388 00361000
+A703A38A a7a02403


### PR DESCRIPTION
Submitting the widescreen cheat used for Soul Reaver, so that it functions as a patch instead, as the built in widescreen rendering does not work as well.

![Legacy of Kain - Soul Reaver (USA) 2025-02-05-04-41-21](https://github.com/user-attachments/assets/12035386-faf1-4271-9405-aa0d063d3456)
