### PR TITLE
Crash Bandicoot 1 Stormy Ascent code

### DIFF
--- a/patches/SCES-00344.cht
+++ b/patches/SCES-00344.cht
@@ -1,0 +1,8 @@
+# Crash Bandicoot (Europe) (EDC) [SCES-00344]
+[Unused Level Stormy Ascent]
+Type = Gameshark
+Activation = EndFrame
+Author = The Cutting Room Floor
+Description = Boots straight into the level when starting the game.
+D0011DD2 3404
+30011DD0 0022

--- a/patches/SCPS-10031.cht
+++ b/patches/SCPS-10031.cht
@@ -1,0 +1,8 @@
+# Crash Bandicoot (Japan, Asia) [SCPS-10031]
+[Unused Level Stormy Ascent]
+Type = Gameshark
+Activation = EndFrame
+Author = The Cutting Room Floor
+Description = Boots straight into the level when starting the game.
+D0011DFA 3404
+30011DF8 0022

--- a/patches/SCUS-94900.cht
+++ b/patches/SCUS-94900.cht
@@ -1,0 +1,8 @@
+# Crash Bandicoot (USA) [SCUS-94900]
+[Unused Level Stormy Ascent]
+Type = Gameshark
+Activation = EndFrame
+Author = The Cutting Room Floor
+Description = Boots straight into the level when starting the game.
+D0011DB2 3404
+30011DB0 0022


### PR DESCRIPTION
GameShark code for all three releases of the game.