### PR TITLE
Update SLUS-00892.cht

### DIFF
--- a/cheats/SLUS-00892.cht
+++ b/cheats/SLUS-00892.cht
@@ -696,6 +696,13 @@ Type = Gameshark
 Activation = EndFrame
 A709F2EA 18402400
 
+[Set Quantity of Cards Won]
+Type = Gameshark
+Activation = EndFrame
+Description = Sets the quantity of each card rewarded after winning in Triple Triad. Choose between 2-100
+OptionRange = 0x02:0x64
+80023954 00??
+
 [Peek at teams cards before starting "Hold select"]
 Type = Gameshark
 Activation = EndFrame


### PR DESCRIPTION
Added cheat that lets you set the quantity between 2-100 of each card won from Triple Triad. (Note: Quantity of owned cards can exceed 100 when winning multiple copies of a card)