### PR TITLE
Gran Turismo 1/2 - Silent's Patches

### DIFF
--- a/patches/SCES-00984.cht
+++ b/patches/SCES-00984.cht
@@ -1,0 +1,20 @@
+# Gran Turismo (Europe) (En,Fr,De,Es,It) [SCES-00984]
+[50 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays will break.
+OverrideCPUOverclock = 200
+A60B6168 00020001
+# Re-enable tire smoke
+A702E560 00020001
+# Re-enable rear view mirror
+A702AA7C 00020001
+
+[Simulation timescale in Arcade]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes the Arcade mode run at 100% game speed like the Simulation mode. (Default is 125%)
+DisallowForAchievements = True
+A7051C80 007D0064

--- a/patches/SCES-02380.cht
+++ b/patches/SCES-02380.cht
@@ -1,0 +1,272 @@
+# Gran Turismo 2 (Europe) (En,Fr,De,Es,It) (Disc 1) (Arcade Mode) [SCES-02380]
+[Widescreen 16:9]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+OverrideAspectRatio = 16:9
+DisableWidescreenRendering = True
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A4052988 801EFB69 # Reset the race overlay for Arcade
+8005D624 0000
+80057090 0000
+00000000 FFFF
+A40529DC 000000F6 # Reset the race overlay for Simulation
+8005D624 0000
+80057090 0000
+00000000 FFFF
+# Car Selection (Arcade)
+A4020A3C 3084007F
+A701E524 FF80FF56
+A701E52C 008000AA
+# Car Selection 2P Battle (Arcade)
+A7020170 FF97FF74
+A7020178 0069008C
+# Pre-race screen (Arcade)
+A701536C 014001AA
+00000000 FFFF
+# Race
+A401F884 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+# Race (Rear view mirror)
+A403EC50 02602021
+A70295E8 FFC4FFB0
+A70295EC 003C0050
+00000000 FFFF
+# Post-race screen #1
+A4057090 260201C0
+# a1 -> t1, *will* change visuals of some screens!
+# Other screens will get slightly resized to compensate for this.
+A7049822 A485A489
+A7049FA0 00C8010A
+A7049FA8 302100C8
+A7049FAA 00A03406
+A704C1EC 00C8010A
+A704C1F4 302100C8
+A704C1F6 00A03406
+# Bonus screen (Licenses)
+# Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704E09C 00000160
+A704E09E 00002405
+A704E0A8 022000C4
+A704E0AA 8FB2A485
+A704E084 016001D5
+# Results screen
+A7050C48 FF50FF16
+A7050C50 00B000EA
+00000000 FFFF
+# Post-race screen #2
+A405D624 8005A640
+A70580AC 00C8010A
+A70580B4 302100C8
+A70580B6 00A03406
+A7058960 00C8010A
+A7058968 302100C8
+A705896A 00A03406
+# Bonus screen (Trophy)
+A7059A50 016001D5
+00000000 FFFF
+# GT Mode screens (Simulation)
+A4024398 80022914
+A701CD68 00B30086
+A701CD70 FFCEFFDB
+A701CD78 03200258
+00000000 FFFF
+
+[50 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays and AI ghost in Rally events will break. Consider switching back to 25 FPS for those events.
+OverrideCPUOverclock = 325
+E01D5894 0002
+301D5894 0001
+A401F884 AEB40008
+# Re-enable tire smoke
+A70168C4 00020000
+# Re-enable sky in the read view mirror
+A7019640 00020000
+00000000 FFFF
+# Re-enable rear view mirror
+A003EC50 02602021
+A702954C 00020000
+
+[Metric units fix]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Fixes a "Launch speed at X mph" text, which was wrongly labeled as showing miles per hour, but showed kilometers per hour.
+# mph launch speed -> km/h launch speed text
+A71C7131 706D6D6B
+A71C7133 0068682F
+
+[Full detail AI cars]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Requires the "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A401F884 AEB40008
+A7014344 00405112
+A7014346 16A00800
+A7014348 00030001 # Set to 0003 to force the lowest LOD
+00000000 FFFF
+
+[Slightly higher draw distance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Benefits from "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A403EC50 02602021
+A702041C 0004810C
+A702041E 14400800
+00000000 FFFF
+
+[HUD & rear view mirror toggle ]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Allows to toggle the rear view mirror by tapping L3 (cycling between “always on”, “default” and “always off”) and toggle the entire HUD by holding L3.
+A403EC50 02602021
+D7010001 00000200
+A0029520 1040000C
+90029520 00000001 # Always on
+A0029520 0800A555
+90029520 1040000C # Default
+A0029520 00000000
+90029520 0800A555 # Always off
+# Fixup canary
+A0029520 00000001
+90029520 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC50 02602021
+D701003C 00000200
+F5029430 0022A52F
+F5029432 14400800
+F5029420 BA120000
+F5029422 0C000000
+00000000 FFFF
+00000000 FFFF
+
+[Replay cameras in race]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes all replay cameras accessible in race, and allows to switch the cinematic camera by holding R1.
+A401F884 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+C30A954C 0001 # Replay off
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F884 AEB40008
+# Hold R1 to trigger a cinematic camera
+C30A954C 0001 # Replay off
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Restore everything when replay is enabled
+A401F884 AEB40008
+C40A954C 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+
+[BGM Switch]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = This patch allows for switching the in-race music by pressing R3. Holding R3 will mute music instead.
+# Check for the R3 key
+D702003C 02000400
+51050005 01
+00000000 FFFF
+# If held for over 60 frames, mute
+52900002 0000003C
+51050005 02
+00000000 FFFF
+# If released before 60 frames passed, switch
+52900002 00000000
+52100005 01
+51050005 03
+00000000 FFFF
+00000000 FFFF
+# Obtain the pointers only if we need it
+51050003 00
+A403EC50 02602021
+52130005 02
+51810003 0002F524
+51060304 000002EE
+00000000 FFFF
+00000000 FFFF
+# If the audio pointer is 0, abort (so we don't have to check again)
+52130005 02
+52900003 00000000
+51050005 00
+00000000 FFFF
+00000000 FFFF
+# Switch BGM
+52100005 03
+52150004 05
+51030404 01
+52120004 05
+51050004 00
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Unmute
+52100005 03
+52100004 FE
+51050004 00
+00000000 FFFF
+00000000 FFFF
+# Mute
+52100005 02
+52150004 05
+51050004 FE
+00000000 FFFF
+00000000 FFFF
+# Apply changes
+52910003 00000000
+51830303 000002EE
+51040403 00
+51050005 00
+00000000 FFFF
+
+[Use 8MB RAM for polygon buffers]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = A patch code moving the polygon buffers to the dev RAM area and doubling their size. Required by other patches that make the game render more geometry on screen at once.
+Enable8MBRAM = True
+A401F884 AEB40008
+# Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F886 AEB4
+A7016A68 000E8020
+D121F886 AEB4
+A7016A6C 57000000
+D121F886 AEB4
+A7016A78 00030007
+D121F886 AEB4
+A7016A74 28210000
+D121F886 AEB4
+A7016A76 02250000
+D121F886 AEB4
+A7016A84 80000000
+00000000 FFFF

--- a/patches/SCES-12380.cht
+++ b/patches/SCES-12380.cht
@@ -1,0 +1,324 @@
+# Gran Turismo 2 (Europe) (En,Fr,De,Es,It) (Disc 2) (Gran Turismo Mode) [SCES-12380]
+[Widescreen 16:9]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+OverrideAspectRatio = 16:9
+DisableWidescreenRendering = True
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A4052988 801EFB69 # Reset the race overlay for Arcade
+8005D624 0000
+80057090 0000
+00000000 FFFF
+A40529DC 000000F6 # Reset the race overlay for Simulation
+8005D624 0000
+80057090 0000
+00000000 FFFF
+# Car Selection (Arcade)
+A4020A3C 3084007F
+A701E524 FF80FF56
+A701E52C 008000AA
+# Car Selection 2P Battle (Arcade)
+A7020170 FF97FF74
+A7020178 0069008C
+# Pre-race screen (Arcade)
+A701536C 014001AA
+00000000 FFFF
+# Race
+A401F884 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+# Race (Rear view mirror)
+A403EC50 02602021
+A70295E8 FFC4FFB0
+A70295EC 003C0050
+00000000 FFFF
+# Post-race screen #1
+A4057090 260201C0
+# a1 -> t1, *will* change visuals of some screens!
+# Other screens will get slightly resized to compensate for this.
+A7049822 A485A489
+A7049FA0 00C8010A
+A7049FA8 302100C8
+A7049FAA 00A03406
+A704C1EC 00C8010A
+A704C1F4 302100C8
+A704C1F6 00A03406
+# Bonus screen (Licenses)
+# Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704E09C 00000160
+A704E09E 00002405
+A704E0A8 022000C4
+A704E0AA 8FB2A485
+A704E084 016001D5
+# Results screen
+A7050C48 FF50FF16
+A7050C50 00B000EA
+00000000 FFFF
+# Post-race screen #2
+A405D624 8005A640
+A70580AC 00C8010A
+A70580B4 302100C8
+A70580B6 00A03406
+A7058960 00C8010A
+A7058968 302100C8
+A705896A 00A03406
+# Bonus screen (Trophy)
+A7059A50 016001D5
+00000000 FFFF
+# GT Mode screens (Simulation)
+A4024398 80022914
+A701CD68 00B30086
+A701CD70 FFCEFFDB
+A701CD78 03200258
+00000000 FFFF
+
+[50 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays and AI ghost in Rally events will break. Consider switching back to 25 FPS for those events.
+OverrideCPUOverclock = 325
+E01D5894 0002
+301D5894 0001
+A401F884 AEB40008
+# Re-enable tire smoke
+A70168C4 00020000
+# Re-enable sky in the read view mirror
+A7019640 00020000
+00000000 FFFF
+# Re-enable rear view mirror
+A003EC50 02602021
+A702954C 00020000
+
+[Metric units fix]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Fixes a "Launch speed at X mph" text, which was wrongly labeled as showing miles per hour, but showed kilometers per hour.
+# mph launch speed -> km/h launch speed text
+A71C7131 706D6D6B
+A71C7133 0068682F
+
+[Full detail AI cars]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Requires the "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A401F884 AEB40008
+A7014344 00405112
+A7014346 16A00800
+A7014348 00030001 # Set to 0003 to force the lowest LOD
+00000000 FFFF
+
+[Slightly higher draw distance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Benefits from "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A403EC50 02602021
+A702041C 0004810C
+A702041E 14400800
+00000000 FFFF
+
+[HUD & rear view mirror toggle ]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Allows to toggle the rear view mirror by tapping L3 (cycling between “always on”, “default” and “always off”) and toggle the entire HUD by holding L3.
+A403EC50 02602021
+D7010001 00000200
+A0029520 1040000C
+90029520 00000001 # Always on
+A0029520 0800A555
+90029520 1040000C # Default
+A0029520 00000000
+90029520 0800A555 # Always off
+# Fixup canary
+A0029520 00000001
+90029520 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC50 02602021
+D701003C 00000200
+F5029430 0022A52F
+F5029432 14400800
+F5029420 BA120000
+F5029422 0C000000
+00000000 FFFF
+00000000 FFFF
+
+[Replay cameras in race]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes all replay cameras accessible in race, and allows to switch the cinematic camera by holding R1.
+A401F884 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+C30A954C 0001 # Replay off
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F884 AEB40008
+# Hold R1 to trigger a cinematic camera
+C30A954C 0001 # Replay off
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Restore everything when replay is enabled
+A401F884 AEB40008
+C40A954C 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+
+[True Endurance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = "Millenium In Rome 2 Hours Endurance" event ends after 2 hours, regardless of how many laps were finished (like in PS2 Gran Turismos).
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A0052988 801EFB39 # Reset the race overlay for Arcade
+80057090 0000
+A00529DC 000000F6 # Reset the race overlay for Simulation
+80057090 0000
+# Sets 2h Rome Endurance to 255 laps and hides the lap counter
+A4057090 260201C0
+# Set the endurance flag manually for 255 lap races, so replays work properly
+E01D589B 00FF
+E0046F49 0000
+30046F49 0001
+# Time limited race off
+E0046F49 0000
+A602CE60 00020006 # Restore the max laps counter
+# Time limited race on
+C4046F49 0000
+A702CE60 00060002 # Turn off the max laps counter
+# Set laps to 255
+E01D589B 0063
+301D589B 00FF
+00000000 FFFF
+00000000 FFFF
+
+[BGM Switch]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = This patch allows for switching the in-race music by pressing R3. Holding R3 will mute music instead.
+# Check for the R3 key
+D702003C 02000400
+51050005 01
+00000000 FFFF
+# If held for over 60 frames, mute
+52900002 0000003C
+51050005 02
+00000000 FFFF
+# If released before 60 frames passed, switch
+52900002 00000000
+52100005 01
+51050005 03
+00000000 FFFF
+00000000 FFFF
+# Obtain the pointers only if we need it
+51050003 00
+A403EC50 02602021
+52130005 02
+51810003 0002F524
+51060304 000002EE
+00000000 FFFF
+00000000 FFFF
+# If the audio pointer is 0, abort (so we don't have to check again)
+52130005 02
+52900003 00000000
+51050005 00
+00000000 FFFF
+00000000 FFFF
+# Switch BGM
+52100005 03
+52150004 05
+51030404 01
+52120004 05
+51050004 00
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Unmute
+52100005 03
+52100004 FE
+51050004 00
+00000000 FFFF
+00000000 FFFF
+# Mute
+52100005 02
+52150004 05
+51050004 FE
+00000000 FFFF
+00000000 FFFF
+# Apply changes
+52910003 00000000
+51830303 000002EE
+51040403 00
+51050005 00
+00000000 FFFF
+
+[Fixed Event Generator]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Improves randomly generated events (One-Make races and Event Generator races) by fixing the course generation.
+A4024398 80022914
+# new_paramaS -> new_parmaS
+A7022F73 6D61616D
+A7022F75 53610053
+# Add mini/rev_mini (Autumn Ring Mini) to random events
+A70230E8 494C6572
+A70230EA 25535F76
+A70230EC 3230696D
+A70230EE 0064696E
+A70230F0 494C0000
+A0050C54 00000000
+90050C54 800230E8
+A0050C58 800230E8
+90050C58 800230EC
+A0050C5C 800230F0
+90050C5C 00000000
+00000000 FFFF
+
+[Use 8MB RAM for polygon buffers]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = A patch code moving the polygon buffers to the dev RAM area and doubling their size. Required by other patches that make the game render more geometry on screen at once.
+Enable8MBRAM = True
+A401F884 AEB40008
+# Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F886 AEB4
+A7016A68 000E8020
+D121F886 AEB4
+A7016A6C 57000000
+D121F886 AEB4
+A7016A78 00030007
+D121F886 AEB4
+A7016A74 28210000
+D121F886 AEB4
+A7016A76 02250000
+D121F886 AEB4
+A7016A84 80000000
+00000000 FFFF

--- a/patches/SCPS-10045.cht
+++ b/patches/SCPS-10045.cht
@@ -1,0 +1,12 @@
+# Gran Turismo (Japan, Asia) [SCPS-10045]
+[60 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays will break.
+OverrideCPUOverclock = 200
+A60AD648 00020001
+# Re-enable tire smoke
+A702DD08 00020001
+# Re-enable rear view mirror
+A702A548 00020001

--- a/patches/SCPS-10116.cht
+++ b/patches/SCPS-10116.cht
@@ -1,0 +1,286 @@
+# Gran Turismo 2 (Japan, Asia) (Disc 1) (Arcade) [SCPS-10116]
+[Widescreen 16:9]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+OverrideAspectRatio = 16:9
+DisableWidescreenRendering = True
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A405054C 801EDEA0 # Reset the race overlay for Arcade
+8005D1EC 0000
+80056C64 0000
+00000000 FFFF
+A40524D0 00000087 # Reset the race overlay for Simulation
+8005D1EC 0000
+80056C64 0000
+00000000 FFFF
+# Car Selection (Arcade)
+A402085C 3084007F
+A701E374 FF80FF56
+A701E37C 008000AA
+# Car Selection 2P Battle (Arcade)
+A701FF90 FF97FF74
+A701FF98 0069008C
+# Pre-race screen (Arcade)
+A7015340 014001AA
+00000000 FFFF
+# Race
+A401F794 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+# Race (Rear view mirror)
+A403EC18 02602021
+A702953C FFC4FFB0
+A7029540 003C0050
+00000000 FFFF
+# Post-race screen #1
+A4056C64 260201C0
+# a1 -> t1, *will* change visuals of some screens!
+# Other screens will get slightly resized to compensate for this.
+A704971A A485A489
+A7049E54 00C8010A
+A7049E5C 302100C8
+A7049E5E 00A03406
+A704C0A0 00C8010A
+A704C0A8 302100C8
+A704C0AA 00A03406
+# Bonus screen (Licenses)
+# Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DCA8 00000160
+A704DCAA 00002405
+A704DCB4 022000C4
+A704DCB6 8FB2A485
+A704DC90 016001D5
+# Results screen
+A7050804 FF50FF16
+A705080C 00B000EA
+00000000 FFFF
+# Post-race screen #2
+A405D1EC 8005A208
+A7057C80 00C8010A
+A7057C88 302100C8
+A7057C8A 00A03406
+A7058534 00C8010A
+A705853C 302100C8
+A705853E 00A03406
+# Bonus screen (Trophy)
+A7059618 016001D5
+00000000 FFFF
+# GT Mode screens (Simulation)
+A4023F14 800225C8
+A701C9D4 00B30086
+A701C9DC FFCEFFDB
+A701C9E4 03200258
+00000000 FFFF
+
+[60 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays and AI ghost in Rally events will break. Consider switching back to 30 FPS for those events.
+OverrideCPUOverclock = 325
+E01D5CB4 0002
+301D5CB4 0001
+A401F794 AEB40008
+# Re-enable tire smoke
+A70167EC 00020000
+# Re-enable sky in the read view mirror
+A7019550 00020000
+00000000 FFFF
+# Re-enable rear view mirror
+A003EC18 02602021
+A70294A0 00020000
+
+[Full detail AI cars]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Requires the "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A401F794 AEB40008
+A701430C 00405104
+A701430E 16A00800
+A7014310 00030001 # Set to 0003 to force the lowest LOD
+00000000 FFFF
+
+[Slightly higher draw distance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Benefits from "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A403EC18 02602021
+A702032C 000480D0
+A702032E 14400800
+00000000 FFFF
+
+[HUD & rear view mirror toggle ]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Allows to toggle the rear view mirror by tapping L3 (cycling between “always on”, “default” and “always off”) and toggle the entire HUD by holding L3.
+A403EC18 02602021
+D7010001 00000200
+A0029474 1040000C
+90029474 00000001 # Always on
+A0029474 0800A52A
+90029474 1040000C # Default
+A0029474 00000000
+90029474 0800A52A # Always off
+# Fixup canary
+A0029474 00000001
+90029474 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC18 02602021
+D701003C 00000200
+F5029384 0022A504
+F5029386 14400800
+F5029374 B9DC0000
+F5029376 0C000000
+00000000 FFFF
+00000000 FFFF
+
+[Replay cameras in race]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes all replay cameras accessible in race, and allows to switch the cinematic camera by holding R1.
+A401F794 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+C30A9D0C 0001 # Replay off
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F794 AEB40008
+# Hold R1 to trigger a cinematic camera
+C30A9D0C 0001 # Replay off
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Restore everything when replay is enabled
+A401F794 AEB40008
+C40A9D0C 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+
+[BGM Switch]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = This patch allows for switching the in-race music by pressing R3. Holding R3 will mute music instead.
+# Check for the R3 key
+D702003C 02000400
+51050005 01
+00000000 FFFF
+# If held for over 60 frames, mute
+52900002 0000003C
+51050005 02
+00000000 FFFF
+# If released before 60 frames passed, switch
+52900002 00000000
+52100005 01
+51050005 03
+00000000 FFFF
+00000000 FFFF
+# Obtain the pointers only if we need it
+51050003 00
+A403EC18 02602021
+52130005 02
+51810003 0002F44C
+51060304 000002EE
+00000000 FFFF
+00000000 FFFF
+# If the audio pointer is 0, abort (so we don't have to check again)
+52130005 02
+52900003 00000000
+51050005 00
+00000000 FFFF
+00000000 FFFF
+# Switch BGM
+52100005 03
+52150004 05
+51030404 01
+52120004 05
+51050004 00
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Unmute
+52100005 03
+52100004 FE
+51050004 00
+00000000 FFFF
+00000000 FFFF
+# Mute
+52100005 02
+52150004 05
+51050004 FE
+00000000 FFFF
+00000000 FFFF
+# Apply changes
+52910003 00000000
+51830303 000002EE
+51040403 00
+51050005 00
+00000000 FFFF
+
+[Fixed Event Generator]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Improves randomly generated events (One-Make races and Event Generator races) by fixing the course generation.
+A4023F14 800225C8
+# new_paramaS -> new_parmaS
+A7022B6F 6D61616D
+A7022B71 53610053
+# Add mini/rev_mini (Autumn Ring Mini) to random events
+A7022CE4 494C6572
+A7022CE6 25535F76
+A7022CE8 3230696D
+A7022CEA 0064696E
+A7022CEC 494C0000
+A0050760 00000000
+90050760 80022CE4
+A0050764 80022CE4
+90050764 80022CE8
+A0050768 80022CEC
+90050768 00000000
+00000000 FFFF
+
+[Use 8MB RAM for polygon buffers]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = A patch code moving the polygon buffers to the dev RAM area and doubling their size. Required by other patches that make the game render more geometry on screen at once.
+Enable8MBRAM = True
+A401F794 AEB40008
+# Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F796 AEB4
+A7016990 000E8020
+D121F796 AEB4
+A7016994 57000000
+D121F796 AEB4
+A70169A0 00030007
+D121F796 AEB4
+A701699C 28210000
+D121F796 AEB4
+A701699E 02250000
+D121F796 AEB4
+A70169AC 80000000
+00000000 FFFF

--- a/patches/SCPS-10117_15C9C27ADCC5392D.cht
+++ b/patches/SCPS-10117_15C9C27ADCC5392D.cht
@@ -1,0 +1,315 @@
+# Gran Turismo 2 (Japan) (Disc 2) (Gran Turismo) (Rev 1) [SCPS-10117]
+[Widescreen 16:9]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+OverrideAspectRatio = 16:9
+DisableWidescreenRendering = True
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A40527D4 801EF999 # Reset the race overlay for Arcade
+8005D4AC 0000
+80056F24 0000
+00000000 FFFF
+A405257C 000000F6 # Reset the race overlay for Simulation
+8005D4AC 0000
+80056F24 0000
+00000000 FFFF
+# Car Selection (Arcade)
+A4020888 3084007F
+A701E3A0 FF80FF56
+A701E3A8 008000AA
+# Car Selection 2P Battle (Arcade)
+A701FFBC FF97FF74
+A701FFC4 0069008C
+# Pre-race screen (Arcade)
+A701536C 014001AA
+00000000 FFFF
+# Race
+A401F880 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+# Race (Rear view mirror)
+A403EBF0 02602021
+A702960C FFC4FFB0
+A7029610 003C0050
+00000000 FFFF
+# Post-race screen #1
+A4056F24 260201C0
+# a1 -> t1, *will* change visuals of some screens!
+# Other screens will get slightly resized to compensate for this.
+A7049726 A485A489
+A7049EA4 00C8010A
+A7049EAC 302100C8
+A7049EAE 00A03406
+A704C0F0 00C8010A
+A704C0F8 302100C8
+A704C0FA 00A03406
+# Bonus screen (Licenses)
+# Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DF7C 00000160
+A704DF7E 00002405
+A704DF88 022000C4
+A704DF8A 8FB2A485
+A704DF64 016001D5
+# Results screen
+A7050B14 FF50FF16
+A7050B1C 00B000EA
+00000000 FFFF
+# Post-race screen #2
+A405D4AC 8005A4C8
+A7057F40 00C8010A
+A7057F48 302100C8
+A7057F4A 00A03406
+A70587F4 00C8010A
+A70587FC 302100C8
+A70587FE 00A03406
+# Bonus screen (Trophy)
+A70598D8 016001D5
+00000000 FFFF
+# GT Mode screens (Simulation)
+A4023F98 800225CC
+A701C9D4 00B30086
+A701C9DC FFCEFFDB
+A701C9E4 03200258
+00000000 FFFF
+
+[60 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays and AI ghost in Rally events will break. Consider switching back to 30 FPS for those events.
+OverrideCPUOverclock = 325
+E01D56C4 0002
+301D56C4 0001
+A401F880 AEB40008
+# Re-enable tire smoke
+A70168C0 00020000
+# Re-enable sky in the read view mirror
+A701963C 00020000
+00000000 FFFF
+# Re-enable rear view mirror
+A003EBF0 02602021
+A7029570 00020000
+
+[Full detail AI cars]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Requires the "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A401F880 AEB40008
+A701433C 00405110
+A701433E 16A00800
+A7014340 00030001 # Set to 0003 to force the lowest LOD
+00000000 FFFF
+
+[Slightly higher draw distance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Benefits from "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A403EBF0 02602021
+A7020418 0004810B
+A702041A 14400800
+00000000 FFFF
+
+[HUD & rear view mirror toggle ]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Allows to toggle the rear view mirror by tapping L3 (cycling between “always on”, “default” and “always off”) and toggle the entire HUD by holding L3.
+A403EBF0 02602021
+D7010001 00000200
+A0029544 1040000C
+90029544 00000001 # Always on
+A0029544 0800A55E
+90029544 1040000C # Default
+A0029544 00000000
+90029544 0800A55E # Always off
+# Fixup canary
+A0029544 00000001
+90029544 00000000
+00000000 FFFF
+00000000 FFFF
+A403EBF0 02602021
+D701003C 00000200
+F5029454 0022A538
+F5029456 14400800
+F5029444 BA0E0000
+F5029446 0C000000
+00000000 FFFF
+00000000 FFFF
+
+[Replay cameras in race]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes all replay cameras accessible in race, and allows to switch the cinematic camera by holding R1.
+A401F880 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+C30A937C 0001 # Replay off
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F880 AEB40008
+# Hold R1 to trigger a cinematic camera
+C30A937C 0001 # Replay off
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FF9AD 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Restore everything when replay is enabled
+A401F880 AEB40008
+C40A937C 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+
+[True Endurance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = "Millenium In Rome 2 Hours Endurance" event ends after 2 hours, regardless of how many laps were finished (like in PS2 Gran Turismos).
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A00527D4 801EF999 # Reset the race overlay for Arcade
+80056F24 0000
+A005257C 000000F6 # Reset the race overlay for Simulation
+80056F24 0000
+# Sets 2h Rome Endurance to 255 laps and hides the lap counter
+A4056F24 260201C0
+# Set the endurance flag manually for 255 lap races, so replays work properly
+E01D56CB 00FF
+E0046EC5 0000
+30046EC5 0001
+# Time limited race off
+E0046EC5 0000
+A602CE44 00020006 # Restore the max laps counter
+# Time limited race on
+C4046EC5 0000
+A702CE44 00060002 # Turn off the max laps counter
+# Set laps to 255
+E01D56CB 0063
+301D56CB 00FF
+00000000 FFFF
+00000000 FFFF
+
+[BGM Switch]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = This patch allows for switching the in-race music by pressing R3. Holding R3 will mute music instead.
+# Check for the R3 key
+D702003C 02000400
+51050005 01
+00000000 FFFF
+# If held for over 60 frames, mute
+52900002 0000003C
+51050005 02
+00000000 FFFF
+# If released before 60 frames passed, switch
+52900002 00000000
+52100005 01
+51050005 03
+00000000 FFFF
+00000000 FFFF
+# Obtain the pointers only if we need it
+51050003 00
+A403EBF0 02602021
+52130005 02
+51810003 0002F514
+51060304 000002EE
+00000000 FFFF
+00000000 FFFF
+# If the audio pointer is 0, abort (so we don't have to check again)
+52130005 02
+52900003 00000000
+51050005 00
+00000000 FFFF
+00000000 FFFF
+# Switch BGM
+52100005 03
+52150004 05
+51030404 01
+52120004 05
+51050004 00
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Unmute
+52100005 03
+52100004 FE
+51050004 00
+00000000 FFFF
+00000000 FFFF
+# Mute
+52100005 02
+52150004 05
+51050004 FE
+00000000 FFFF
+00000000 FFFF
+# Apply changes
+52910003 00000000
+51830303 000002EE
+51040403 00
+51050005 00
+00000000 FFFF
+
+[Fixed Event Generator]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Improves randomly generated events (One-Make races and Event Generator races) by fixing the course generation.
+A4023F98 800225CC
+# new_paramaS -> new_parmaS
+A7022B73 6D61616D
+A7022B75 53610053
+# Add mini/rev_mini (Autumn Ring Mini) to random events
+A7022CE8 494C6572
+A7022CEA 25535F76
+A7022CEC 3230696D
+A7022CEE 0064696E
+A7022CF0 494C0000
+A00507F4 00000000
+900507F4 80022CE8
+A00507F8 80022CE8
+900507F8 80022CEC
+A00507FC 80022CF0
+900507FC 00000000
+00000000 FFFF
+
+[Use 8MB RAM for polygon buffers]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = A patch code moving the polygon buffers to the dev RAM area and doubling their size. Required by other patches that make the game render more geometry on screen at once.
+Enable8MBRAM = True
+A401F880 AEB40008
+# Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F882 AEB4
+A7016A64 000E8020
+D121F882 AEB4
+A7016A68 57000000
+D121F882 AEB4
+A7016A74 00030007
+D121F882 AEB4
+A7016A70 28210000
+D121F882 AEB4
+A7016A72 02250000
+D121F882 AEB4
+A7016A80 80000000
+00000000 FFFF

--- a/patches/SCPS-10117_AF43A0F5B7E3BA22.cht
+++ b/patches/SCPS-10117_AF43A0F5B7E3BA22.cht
@@ -1,0 +1,286 @@
+# Gran Turismo 2 (Japan, Asia) (Disc 2) (Gran Turismo) [SCPS-10117]
+[Widescreen 16:9]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+OverrideAspectRatio = 16:9
+DisableWidescreenRendering = True
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A405054C 801EDEA0 # Reset the race overlay for Arcade
+8005D1EC 0000
+80056C64 0000
+00000000 FFFF
+A40524D0 00000087 # Reset the race overlay for Simulation
+8005D1EC 0000
+80056C64 0000
+00000000 FFFF
+# Car Selection (Arcade)
+A402085C 3084007F
+A701E374 FF80FF56
+A701E37C 008000AA
+# Car Selection 2P Battle (Arcade)
+A701FF90 FF97FF74
+A701FF98 0069008C
+# Pre-race screen (Arcade)
+A7015340 014001AA
+00000000 FFFF
+# Race
+A401F794 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+# Race (Rear view mirror)
+A403EC18 02602021
+A702953C FFC4FFB0
+A7029540 003C0050
+00000000 FFFF
+# Post-race screen #1
+A4056C64 260201C0
+# a1 -> t1, *will* change visuals of some screens!
+# Other screens will get slightly resized to compensate for this.
+A704971A A485A489
+A7049E54 00C8010A
+A7049E5C 302100C8
+A7049E5E 00A03406
+A704C0A0 00C8010A
+A704C0A8 302100C8
+A704C0AA 00A03406
+# Bonus screen (Licenses)
+# Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DCA8 00000160
+A704DCAA 00002405
+A704DCB4 022000C4
+A704DCB6 8FB2A485
+A704DC90 016001D5
+# Results screen
+A7050804 FF50FF16
+A705080C 00B000EA
+00000000 FFFF
+# Post-race screen #2
+A405D1EC 8005A208
+A7057C80 00C8010A
+A7057C88 302100C8
+A7057C8A 00A03406
+A7058534 00C8010A
+A705853C 302100C8
+A705853E 00A03406
+# Bonus screen (Trophy)
+A7059618 016001D5
+00000000 FFFF
+# GT Mode screens (Simulation)
+A4023F14 800225C8
+A701C9D4 00B30086
+A701C9DC FFCEFFDB
+A701C9E4 03200258
+00000000 FFFF
+
+[60 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays and AI ghost in Rally events will break. Consider switching back to 30 FPS for those events.
+OverrideCPUOverclock = 325
+E01D5CC4 0002
+301D5CC4 0001
+A401F794 AEB40008
+# Re-enable tire smoke
+A70167EC 00020000
+# Re-enable sky in the read view mirror
+A7019550 00020000
+00000000 FFFF
+# Re-enable rear view mirror
+A003EC18 02602021
+A70294A0 00020000
+
+[Full detail AI cars]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Requires the "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A401F794 AEB40008
+A701430C 00405104
+A701430E 16A00800
+A7014310 00030001 # Set to 0003 to force the lowest LOD
+00000000 FFFF
+
+[Slightly higher draw distance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Benefits from "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A403EC18 02602021
+A702032C 000480D0
+A702032E 14400800
+00000000 FFFF
+
+[HUD & rear view mirror toggle ]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Allows to toggle the rear view mirror by tapping L3 (cycling between “always on”, “default” and “always off”) and toggle the entire HUD by holding L3.
+A403EC18 02602021
+D7010001 00000200
+A0029474 1040000C
+90029474 00000001 # Always on
+A0029474 0800A52A
+90029474 1040000C # Default
+A0029474 00000000
+90029474 0800A52A # Always off
+# Fixup canary
+A0029474 00000001
+90029474 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC18 02602021
+D701003C 00000200
+F5029384 0022A504
+F5029386 14400800
+F5029374 B9DC0000
+F5029376 0C000000
+00000000 FFFF
+00000000 FFFF
+
+[Replay cameras in race]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes all replay cameras accessible in race, and allows to switch the cinematic camera by holding R1.
+A401F794 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+C30A9D1C 0001 # Replay off
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F794 AEB40008
+# Hold R1 to trigger a cinematic camera
+C30A9D1C 0001 # Replay off
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA81 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Restore everything when replay is enabled
+A401F794 AEB40008
+C40A9D1C 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+
+[BGM Switch]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = This patch allows for switching the in-race music by pressing R3. Holding R3 will mute music instead.
+# Check for the R3 key
+D702003C 02000400
+51050005 01
+00000000 FFFF
+# If held for over 60 frames, mute
+52900002 0000003C
+51050005 02
+00000000 FFFF
+# If released before 60 frames passed, switch
+52900002 00000000
+52100005 01
+51050005 03
+00000000 FFFF
+00000000 FFFF
+# Obtain the pointers only if we need it
+51050003 00
+A403EC18 02602021
+52130005 02
+51810003 0002F44C
+51060304 000002EE
+00000000 FFFF
+00000000 FFFF
+# If the audio pointer is 0, abort (so we don't have to check again)
+52130005 02
+52900003 00000000
+51050005 00
+00000000 FFFF
+00000000 FFFF
+# Switch BGM
+52100005 03
+52150004 05
+51030404 01
+52120004 05
+51050004 00
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Unmute
+52100005 03
+52100004 FE
+51050004 00
+00000000 FFFF
+00000000 FFFF
+# Mute
+52100005 02
+52150004 05
+51050004 FE
+00000000 FFFF
+00000000 FFFF
+# Apply changes
+52910003 00000000
+51830303 000002EE
+51040403 00
+51050005 00
+00000000 FFFF
+
+[Fixed Event Generator]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Improves randomly generated events (One-Make races and Event Generator races) by fixing the course generation.
+A4023F14 800225C8
+# new_paramaS -> new_parmaS
+A7022B6F 6D61616D
+A7022B71 53610053
+# Add mini/rev_mini (Autumn Ring Mini) to random events
+A7022CE4 494C6572
+A7022CE6 25535F76
+A7022CE8 3230696D
+A7022CEA 0064696E
+A7022CEC 494C0000
+A0050760 00000000
+90050760 80022CE4
+A0050764 80022CE4
+90050764 80022CE8
+A0050768 80022CEC
+90050768 00000000
+00000000 FFFF
+
+[Use 8MB RAM for polygon buffers]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = A patch code moving the polygon buffers to the dev RAM area and doubling their size. Required by other patches that make the game render more geometry on screen at once.
+Enable8MBRAM = True
+A401F794 AEB40008
+# Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F796 AEB4
+A7016990 000E8020
+D121F796 AEB4
+A7016994 57000000
+D121F796 AEB4
+A70169A0 00030007
+D121F796 AEB4
+A701699C 28210000
+D121F796 AEB4
+A701699E 02250000
+D121F796 AEB4
+A70169AC 80000000
+00000000 FFFF

--- a/patches/SCUS-94194_BB97C4A16C475EC8.cht
+++ b/patches/SCUS-94194_BB97C4A16C475EC8.cht
@@ -1,0 +1,20 @@
+# Gran Turismo (USA) (Rev 1) [SCUS-94194]
+[60 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays will break.
+OverrideCPUOverclock = 200
+A60B6348 00020001
+# Re-enable tire smoke
+A702E548 00020001
+# Re-enable rear view mirror
+A702AA3C 00020001
+
+[Simulation timescale in Arcade]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes the Arcade mode run at 100% game speed like the Simulation mode. (Default is 125%)
+DisallowForAchievements = True
+A7051C6C 007D0064

--- a/patches/SCUS-94194_EB6969139DF1F660.cht
+++ b/patches/SCUS-94194_EB6969139DF1F660.cht
@@ -1,0 +1,12 @@
+# Gran Turismo (USA) [SCUS-94194]
+[60 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays will break.
+OverrideCPUOverclock = 200
+A60B6318 00020001
+# Re-enable tire smoke
+A702E580 00020001
+# Re-enable rear view mirror
+A702AA74 00020001

--- a/patches/SCUS-94455_4D4143598FCDB870.cht
+++ b/patches/SCUS-94455_4D4143598FCDB870.cht
@@ -1,0 +1,351 @@
+# Gran Turismo 2 (USA) (Arcade Mode) (Rev 1) [SCUS-94455]
+[Widescreen 16:9]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+OverrideAspectRatio = 16:9
+DisableWidescreenRendering = True
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A4052A64 801EF8EF # Reset the race overlay for Arcade
+8005D598 0000
+80057010 0000
+00000000 FFFF
+A4052B20 000000E7 # Reset the race overlay for Simulation
+8005D598 0000
+80057010 0000
+00000000 FFFF
+# Car Selection (Arcade)
+A4020A74 3084007F
+A701E55C FF80FF56
+A701E564 008000AA
+# Car Selection 2P Battle (Arcade)
+A70201A8 FF97FF74
+A70201B0 0069008C
+# Pre-race screen (Arcade)
+A7015350 014001AA
+00000000 FFFF
+# Race
+A401F888 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+# Race (Rear view mirror)
+A403EC6C 02602021
+A70295E4 FFC4FFB0
+A70295E8 003C0050
+00000000 FFFF
+# Post-race screen #1
+A4057010 260201C0
+# a1 -> t1, *will* change visuals of some screens!
+# Other screens will get slightly resized to compensate for this.
+A7049736 A485A489
+A7049EB4 00C8010A
+A7049EBC 302100C8
+A7049EBE 00A03406
+A704C100 00C8010A
+A704C108 302100C8
+A704C10A 00A03406
+# Bonus screen (Licenses)
+# Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DFE8 00000160
+A704DFEA 00002405
+A704DFF4 022000C4
+A704DFF6 8FB2A485
+A704DFD0 016001D5
+# Results screen
+A7050B80 FF50FF16
+A7050B88 00B000EA
+00000000 FFFF
+# Post-race screen #2
+A405D598 8005A5B4
+A705802C 00C8010A
+A7058034 302100C8
+A7058036 00A03406
+A70588E0 00C8010A
+A70588E8 302100C8
+A70588EA 00A03406
+# Bonus screen (Trophy)
+A70599C4 016001D5
+00000000 FFFF
+# GT Mode screens (Simulation)
+A40244EC 800229D8
+A701CDF4 00B30086
+A701CDFC FFCEFFDB
+A701CE04 03200258
+00000000 FFFF
+
+[60 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays and AI ghost in Rally events will break. Consider switching back to 30 FPS for those events.
+OverrideCPUOverclock = 325
+E01D5634 0002
+301D5634 0001
+A401F888 AEB40008
+# Re-enable tire smoke
+A70168C8 00020000
+# Re-enable sky in the read view mirror
+A7019644 00020000
+00000000 FFFF
+# Re-enable rear view mirror
+A003EC6C 02602021
+A7029548 00020000
+
+[Metric units]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A0052A64 801EF8EF # Reset the race overlay for Arcade
+80057010 0000
+A0052B20 000000E7 # Reset the race overlay for Simulation
+80057010 0000
+# Localization changes
+# mph text -> km/h text (lap times)
+A71C6A27 706D6D6B
+A71C6A29 0068682F
+# ft text -> m text (Arcade)
+A70F853D 7466006D
+# lb text -> kg text (Arcade)
+A70F8435 626C676B
+# lb-ft text -> kgm text (Arcade)
+A70F8474 626C676B
+A70F8476 662D2F6D
+A70F8478 2F746425
+A70F847A 64257072
+A70F847C 7072006D
+A70F8487 626C676B
+A70F8489 662D2F6D
+A70F848B 2F74257E
+A70F848D 257E7264
+A70F848F 72646D70
+A70F8491 6D700000
+# lb-ft text -> kgm text (Arcade graph)
+A70F835A 626C676B
+A70F835C 662D006D
+# mph launch speed -> km/h launch speed text (License tests)
+A71C6EA9 706D6D6B
+A71C6EAB 0068682F
+# lb text -> kg text (Simulation garage)
+A71EF476 626C676B
+# lb-ft text -> kgm text (Simulation garage)
+A71C2EA7 626C676B
+A71C2EA9 662D206D
+A71C2EAB 2074202F
+A71C2EAD 202F0000
+# Code changes
+A403EC6C 02602021
+# mph text -> km/h text (speedometer)
+A702F6F4 B0D8A0C0
+A702F6F6 39233922
+# Speed unit scaling
+A7030568 000D0016
+A703056C FBDD8000
+00000000 FFFF
+A4020A74 3084007F
+# Weight unit scaling (Arcade)
+A7018AC8 13030000
+A7018ACA 00090000
+A7018AD0 30230000
+A7018AD2 00463446
+# Torque unit scaling (Arcade)
+A7018C0C 17C30000
+A7018C0E 000234A8
+A7018C20 40230000
+A7018C22 00620000
+# Torque graph scaling (Arcade)
+A7019798 18230004
+A701979A 00629683
+A70198B2 ACC3ACC4
+00000000 FFFF
+# Speed unit scaling (License tests)
+A4057010 260201C0
+A704D984 37C30000
+A704D986 00069506
+A704D994 30230000
+A704D996 00460000
+00000000 FFFF
+A40244EC 800229D8
+# Weight unit scaling (Simulation screens)
+A701C968 48100000
+A701C974 302303A4
+A701C976 00468D26
+A701C564 48100000
+A701C570 302303A4
+A701C572 00468D26
+# Torque unit scaling (Simulation screens)
+A701C808 40230000
+A701C80A 00620000
+00000000 FFFF
+
+[Full detail AI cars]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Requires the "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A401F888 AEB40008
+A7014344 00405112
+A7014346 16A00800
+A7014348 00030001 # Set to 0003 to force the lowest LOD
+00000000 FFFF
+
+[Slightly higher draw distance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Benefits from "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A403EC6C 02602021
+A7020420 0004810D
+A7020422 14400800
+00000000 FFFF
+
+[HUD & rear view mirror toggle ]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Allows to toggle the rear view mirror by tapping L3 (cycling between “always on”, “default” and “always off”) and toggle the entire HUD by holding L3.
+A403EC6C 02602021
+D7010001 00000200
+A002951C 1040000C
+9002951C 00000001 # Always on
+A002951C 0800A554
+9002951C 1040000C # Default
+A002951C 00000000
+9002951C 0800A554 # Always off
+# Fixup canary
+A002951C 00000001
+9002951C 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC6C 02602021
+D701003C 00000200
+F502942C 0022A52E
+F502942E 14400800
+F502941C BA040000
+F502941E 0C000000
+00000000 FFFF
+00000000 FFFF
+
+[Replay cameras in race]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes all replay cameras accessible in race, and allows to switch the cinematic camera by holding R1.
+A401F888 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+C30A92BC 0001 # Replay off
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F888 AEB40008
+# Hold R1 to trigger a cinematic camera
+C30A92BC 0001 # Replay off
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Restore everything when replay is enabled
+A401F888 AEB40008
+C40A92BC 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+
+[BGM Switch]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = This patch allows for switching the in-race music by pressing R3. Holding R3 will mute music instead.
+# Check for the R3 key
+D702003C 02000400
+51050005 01
+00000000 FFFF
+# If held for over 60 frames, mute
+52900002 0000003C
+51050005 02
+00000000 FFFF
+# If released before 60 frames passed, switch
+52900002 00000000
+52100005 01
+51050005 03
+00000000 FFFF
+00000000 FFFF
+# Obtain the pointers only if we need it
+51050003 00
+A403EC6C 02602021
+52130005 02
+51810003 0002F4EC
+51060304 000002EE
+00000000 FFFF
+00000000 FFFF
+# If the audio pointer is 0, abort (so we don't have to check again)
+52130005 02
+52900003 00000000
+51050005 00
+00000000 FFFF
+00000000 FFFF
+# Switch BGM
+52100005 03
+52150004 05
+51030404 01
+52120004 05
+51050004 00
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Unmute
+52100005 03
+52100004 FE
+51050004 00
+00000000 FFFF
+00000000 FFFF
+# Mute
+52100005 02
+52150004 05
+51050004 FE
+00000000 FFFF
+00000000 FFFF
+# Apply changes
+52910003 00000000
+51830303 000002EE
+51040403 00
+51050005 00
+00000000 FFFF
+
+[Use 8MB RAM for polygon buffers]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = A patch code moving the polygon buffers to the dev RAM area and doubling their size. Required by other patches that make the game render more geometry on screen at once.
+Enable8MBRAM = True
+A401F888 AEB40008
+# Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F88A AEB4
+A7016A6C 000E8020
+D121F88A AEB4
+A7016A70 57000000
+D121F88A AEB4
+A7016A7C 00030007
+D121F88A AEB4
+A7016A78 28210000
+D121F88A AEB4
+A7016A7A 02250000
+D121F88A AEB4
+A7016A88 80000000
+00000000 FFFF

--- a/patches/SCUS-94488_6C4C043E1B0B34C6.cht
+++ b/patches/SCUS-94488_6C4C043E1B0B34C6.cht
@@ -1,0 +1,403 @@
+# Gran Turismo 2 (USA) (Simulation Mode) (Rev 1) [SCUS-94488]
+[Widescreen 16:9]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+OverrideAspectRatio = 16:9
+DisableWidescreenRendering = True
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A4052A64 801EF8EF # Reset the race overlay for Arcade
+8005D598 0000
+80057010 0000
+00000000 FFFF
+A4052B20 000000E7 # Reset the race overlay for Simulation
+8005D598 0000
+80057010 0000
+00000000 FFFF
+# Car Selection (Arcade)
+A4020A74 3084007F
+A701E55C FF80FF56
+A701E564 008000AA
+# Car Selection 2P Battle (Arcade)
+A70201A8 FF97FF74
+A70201B0 0069008C
+# Pre-race screen (Arcade)
+A7015350 014001AA
+00000000 FFFF
+# Race
+A401F888 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+# Race (Rear view mirror)
+A403EC6C 02602021
+A70295E4 FFC4FFB0
+A70295E8 003C0050
+00000000 FFFF
+# Post-race screen #1
+A4057010 260201C0
+# a1 -> t1, *will* change visuals of some screens!
+# Other screens will get slightly resized to compensate for this.
+A7049736 A485A489
+A7049EB4 00C8010A
+A7049EBC 302100C8
+A7049EBE 00A03406
+A704C100 00C8010A
+A704C108 302100C8
+A704C10A 00A03406
+# Bonus screen (Licenses)
+# Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DFE8 00000160
+A704DFEA 00002405
+A704DFF4 022000C4
+A704DFF6 8FB2A485
+A704DFD0 016001D5
+# Results screen
+A7050B80 FF50FF16
+A7050B88 00B000EA
+00000000 FFFF
+# Post-race screen #2
+A405D598 8005A5B4
+A705802C 00C8010A
+A7058034 302100C8
+A7058036 00A03406
+A70588E0 00C8010A
+A70588E8 302100C8
+A70588EA 00A03406
+# Bonus screen (Trophy)
+A70599C4 016001D5
+00000000 FFFF
+# GT Mode screens (Simulation)
+A40244EC 800229D8
+A701CDF4 00B30086
+A701CDFC FFCEFFDB
+A701CE04 03200258
+00000000 FFFF
+
+[60 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays and AI ghost in Rally events will break. Consider switching back to 30 FPS for those events.
+OverrideCPUOverclock = 325
+E01D5634 0002
+301D5634 0001
+A401F888 AEB40008
+# Re-enable tire smoke
+A70168C8 00020000
+# Re-enable sky in the read view mirror
+A7019644 00020000
+00000000 FFFF
+# Re-enable rear view mirror
+A003EC6C 02602021
+A7029548 00020000
+
+[Metric units]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A0052A64 801EF8EF # Reset the race overlay for Arcade
+80057010 0000
+A0052B20 000000E7 # Reset the race overlay for Simulation
+80057010 0000
+# Localization changes
+# mph text -> km/h text (lap times)
+A71C6A27 706D6D6B
+A71C6A29 0068682F
+# ft text -> m text (Arcade)
+A70F853D 7466006D
+# lb text -> kg text (Arcade)
+A70F8435 626C676B
+# lb-ft text -> kgm text (Arcade)
+A70F8474 626C676B
+A70F8476 662D2F6D
+A70F8478 2F746425
+A70F847A 64257072
+A70F847C 7072006D
+A70F8487 626C676B
+A70F8489 662D2F6D
+A70F848B 2F74257E
+A70F848D 257E7264
+A70F848F 72646D70
+A70F8491 6D700000
+# lb-ft text -> kgm text (Arcade graph)
+A70F835A 626C676B
+A70F835C 662D006D
+# mph launch speed -> km/h launch speed text (License tests)
+A71C6EA9 706D6D6B
+A71C6EAB 0068682F
+# lb text -> kg text (Simulation garage)
+A71EF476 626C676B
+# lb-ft text -> kgm text (Simulation garage)
+A71C2EA7 626C676B
+A71C2EA9 662D206D
+A71C2EAB 2074202F
+A71C2EAD 202F0000
+# Code changes
+A403EC6C 02602021
+# mph text -> km/h text (speedometer)
+A702F6F4 B0D8A0C0
+A702F6F6 39233922
+# Speed unit scaling
+A7030568 000D0016
+A703056C FBDD8000
+00000000 FFFF
+A4020A74 3084007F
+# Weight unit scaling (Arcade)
+A7018AC8 13030000
+A7018ACA 00090000
+A7018AD0 30230000
+A7018AD2 00463446
+# Torque unit scaling (Arcade)
+A7018C0C 17C30000
+A7018C0E 000234A8
+A7018C20 40230000
+A7018C22 00620000
+# Torque graph scaling (Arcade)
+A7019798 18230004
+A701979A 00629683
+A70198B2 ACC3ACC4
+00000000 FFFF
+# Speed unit scaling (License tests)
+A4057010 260201C0
+A704D984 37C30000
+A704D986 00069506
+A704D994 30230000
+A704D996 00460000
+00000000 FFFF
+A40244EC 800229D8
+# Weight unit scaling (Simulation screens)
+A701C968 48100000
+A701C974 302303A4
+A701C976 00468D26
+A701C564 48100000
+A701C570 302303A4
+A701C572 00468D26
+# Torque unit scaling (Simulation screens)
+A701C808 40230000
+A701C80A 00620000
+00000000 FFFF
+
+[Full detail AI cars]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Requires the "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A401F888 AEB40008
+A7014344 00405112
+A7014346 16A00800
+A7014348 00030001 # Set to 0003 to force the lowest LOD
+00000000 FFFF
+
+[Slightly higher draw distance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Benefits from "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A403EC6C 02602021
+A7020420 0004810D
+A7020422 14400800
+00000000 FFFF
+
+[HUD & rear view mirror toggle ]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Allows to toggle the rear view mirror by tapping L3 (cycling between “always on”, “default” and “always off”) and toggle the entire HUD by holding L3.
+A403EC6C 02602021
+D7010001 00000200
+A002951C 1040000C
+9002951C 00000001 # Always on
+A002951C 0800A554
+9002951C 1040000C # Default
+A002951C 00000000
+9002951C 0800A554 # Always off
+# Fixup canary
+A002951C 00000001
+9002951C 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC6C 02602021
+D701003C 00000200
+F502942C 0022A52E
+F502942E 14400800
+F502941C BA040000
+F502941E 0C000000
+00000000 FFFF
+00000000 FFFF
+
+[Replay cameras in race]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes all replay cameras accessible in race, and allows to switch the cinematic camera by holding R1.
+A401F888 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+C30A92BC 0001 # Replay off
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F888 AEB40008
+# Hold R1 to trigger a cinematic camera
+C30A92BC 0001 # Replay off
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Restore everything when replay is enabled
+A401F888 AEB40008
+C40A92BC 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+
+[True Endurance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = "Millenium In Rome 2 Hours Endurance" event ends after 2 hours, regardless of how many laps were finished (like in PS2 Gran Turismos).
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A0052A64 801EF8EF # Reset the race overlay for Arcade
+80057010 0000
+A0052B20 000000E7 # Reset the race overlay for Simulation
+80057010 0000
+# Sets 2h Rome Endurance to 255 laps and hides the lap counter
+A4057010 260201C0
+# Set the endurance flag manually for 255 lap races, so replays work properly
+E01D563B 00FF
+E0046ED5 0000
+30046ED5 0001
+# Time limited race off
+E0046ED5 0000
+A602CE1C 00020006 # Restore the max laps counter
+# Time limited race on
+C4046ED5 0000
+A702CE1C 00060002 # Turn off the max laps counter
+# Set laps to 255
+E01D563B 0063
+301D563B 00FF
+00000000 FFFF
+00000000 FFFF
+
+[BGM Switch]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = This patch allows for switching the in-race music by pressing R3. Holding R3 will mute music instead.
+# Check for the R3 key
+D702003C 02000400
+51050005 01
+00000000 FFFF
+# If held for over 60 frames, mute
+52900002 0000003C
+51050005 02
+00000000 FFFF
+# If released before 60 frames passed, switch
+52900002 00000000
+52100005 01
+51050005 03
+00000000 FFFF
+00000000 FFFF
+# Obtain the pointers only if we need it
+51050003 00
+A403EC6C 02602021
+52130005 02
+51810003 0002F4EC
+51060304 000002EE
+00000000 FFFF
+00000000 FFFF
+# If the audio pointer is 0, abort (so we don't have to check again)
+52130005 02
+52900003 00000000
+51050005 00
+00000000 FFFF
+00000000 FFFF
+# Switch BGM
+52100005 03
+52150004 05
+51030404 01
+52120004 05
+51050004 00
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Unmute
+52100005 03
+52100004 FE
+51050004 00
+00000000 FFFF
+00000000 FFFF
+# Mute
+52100005 02
+52150004 05
+51050004 FE
+00000000 FFFF
+00000000 FFFF
+# Apply changes
+52910003 00000000
+51830303 000002EE
+51040403 00
+51050005 00
+00000000 FFFF
+
+[Fixed Event Generator]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Improves randomly generated events (One-Make races and Event Generator races) by fixing the course generation.
+A40244EC 800229D8
+# new_paramaS -> new_parmaS
+A7023037 6D61616D
+A7023039 53610053
+# Add mini/rev_mini (Autumn Ring Mini) to random events
+A70231AC 494C6572
+A70231AE 25535F76
+A70231B0 3230696D
+A70231B2 0064696E
+A70231B4 494C0000
+A0050D98 00000000
+90050D98 800231AC
+A0050D9C 800231AC
+90050D9C 800231B0
+A0050DA0 800231B4
+90050DA0 00000000
+00000000 FFFF
+
+[Use 8MB RAM for polygon buffers]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = A patch code moving the polygon buffers to the dev RAM area and doubling their size. Required by other patches that make the game render more geometry on screen at once.
+Enable8MBRAM = True
+A401F888 AEB40008
+# Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F88A AEB4
+A7016A6C 000E8020
+D121F88A AEB4
+A7016A70 57000000
+D121F88A AEB4
+A7016A7C 00030007
+D121F88A AEB4
+A7016A78 28210000
+D121F88A AEB4
+A7016A7A 02250000
+D121F88A AEB4
+A7016A88 80000000
+00000000 FFFF

--- a/patches/SCUS-94488_8B7E10FBEC3A5767.cht
+++ b/patches/SCUS-94488_8B7E10FBEC3A5767.cht
@@ -1,0 +1,401 @@
+# Gran Turismo 2 (USA) (Simulation Mode) (Rev 2) [SCUS-94488]
+[Widescreen 16:9]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+OverrideAspectRatio = 16:9
+DisableWidescreenRendering = True
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A40529DC 801EFB39 # Reset the race overlay for Arcade
+8005D5DC 0000
+80057054 0000
+00000000 FFFF
+A4052A70 000000F6 # Reset the race overlay for Simulation
+8005D5DC 0000
+80057054 0000
+00000000 FFFF
+# Car Selection (Arcade)
+A4020A90 3084007F
+A701E578 FF80FF56
+A701E580 008000AA
+# Car Selection 2P Battle (Arcade)
+A70201C4 FF97FF74
+A70201CC 0069008C
+# Pre-race screen (Arcade)
+A701536C 014001AA
+00000000 FFFF
+# Race
+A401F888 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+# Race (Rear view mirror)
+A403EC74 02602021
+A70295EC FFC4FFB0
+A70295F0 003C0050
+00000000 FFFF
+# Post-race screen #1
+A4057054 260201C0
+# a1 -> t1, *will* change visuals of some screens!
+# Other screens will get slightly resized to compensate for this.
+A70497CA A485A489
+A7049F48 00C8010A
+A7049F50 302100C8
+A7049F52 00A03406
+A704C194 00C8010A
+A704C19C 302100C8
+A704C19E 00A03406
+# Bonus screen (Licenses)
+# Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704E07C 00000160
+A704E07E 00002405
+A704E088 022000C4
+A704E08A 8FB2A485
+A704E064 016001D5
+# Results screen
+A7050C14 FF50FF16
+A7050C1C 00B000EA
+00000000 FFFF
+# Post-race screen #2
+A405D5DC 8005A5F8
+A7058070 00C8010A
+A7058078 302100C8
+A705807A 00A03406
+A7058924 00C8010A
+A705892C 302100C8
+A705892E 00A03406
+# Bonus screen (Trophy)
+A7059A08 016001D5
+00000000 FFFF
+# GT Mode screens (Simulation)
+A402442C 800229A8
+A701CDF4 00B30086
+A701CDFC FFCEFFDB
+A701CE04 03200258
+00000000 FFFF
+
+[60 FPS]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = When this patch is in use, existing replays and AI ghost in Rally events will break. Consider switching back to 30 FPS for those events.
+OverrideCPUOverclock = 325
+E01D5864 0002
+301D5864 0001
+A401F888 AEB40008
+# Re-enable tire smoke
+A70168C8 00020000
+# Re-enable sky in the read view mirror
+A7019644 00020000
+00000000 FFFF
+# Re-enable rear view mirror
+A003EC74 02602021
+A7029550 00020000
+
+[Metric units]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A00529DC 801EFB39 # Reset the race overlay for Arcade
+80057054 0000
+A0052A70 000000F6 # Reset the race overlay for Simulation
+80057054 0000
+# Localization changes
+# mph text -> km/h text (lap times)
+A71C6C87 706D6D6B
+A71C6C88 0068682F
+# lb text -> kg text (Arcade)
+A70F8677 626C676B
+# lb-ft text -> kgm text (Arcade)
+A70F86AF 626C676B
+A70F86B1 662D2F6D
+A70F86B3 2F746425
+A70F86B5 64257072
+A70F86B7 7072006D
+A70F86C0 626C676B
+A70F86C2 662D2F6D
+A70F86C4 2F74257E
+A70F86C6 257E7264
+A70F86C8 72646D70
+A70F86CA 6D700000
+# lb-ft text -> kgm text (Arcade graph)
+A70F85A6 626C676B
+A70F85A8 662D006D
+# mph launch speed -> km/h launch speed text (License tests)
+A71C7101 706D6D6B
+A71C7103 0068682F
+# lb text -> kg text (Simulation garage)
+A71EF6C3 626C676B
+# lb-ft text -> kgm text (Simulation garage)
+A71C30FF 626C676B
+A71C3101 662D206D
+A71C3103 2074202F
+A71C3105 202F0000
+# Code changes
+A403EC74 02602021
+# mph text -> km/h text (speedometer)
+A702F6FC B0D8A0C0
+A702F6FE 39233922
+# Speed unit scaling
+A7030570 000D0016
+A7030574 FBDD8000
+00000000 FFFF
+A4020A90 3084007F
+# Weight unit scaling (Arcade)
+A7018AE4 13030000
+A7018AE6 00090000
+A7018AEC 30230000
+A7018AEE 00463446
+# Torque unit scaling (Arcade)
+A7018C28 17C30000
+A7018C2A 000234A8
+A7018C3C 40230000
+A7018C3E 00620000
+# Torque graph scaling (Arcade)
+A70197B4 18230004
+A70197B6 00629683
+A70198CE ACC3ACC4
+00000000 FFFF
+# Speed unit scaling (License tests)
+A4057054 260201C0
+A704DA18 37C30000
+A704DA1A 00069506
+A704DA28 30230000
+A704DA2A 00460000
+00000000 FFFF
+A402442C 800229A8
+# Weight unit scaling (Simulation screens)
+A701C968 48100000
+A701C974 302303A4
+A701C976 00468D26
+A701C564 48100000
+A701C570 302303A4
+A701C572 00468D26
+# Torque unit scaling (Simulation screens)
+A701C808 40230000
+A701C80A 00620000
+00000000 FFFF
+
+[Full detail AI cars]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Requires the "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A401F888 AEB40008
+A7014344 00405112
+A7014346 16A00800
+A7014348 00030001 # Set to 0003 to force the lowest LOD
+00000000 FFFF
+
+[Slightly higher draw distance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Benefits from "Use 8MB RAM for polygon buffers" patch.
+OverrideCPUOverclock = 325
+A403EC74 02602021
+A7020420 0004810D
+A7020422 14400800
+00000000 FFFF
+
+[HUD & rear view mirror toggle ]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Allows to toggle the rear view mirror by tapping L3 (cycling between “always on”, “default” and “always off”) and toggle the entire HUD by holding L3.
+A403EC74 02602021
+D7010001 00000200
+A0029524 1040000C
+90029524 00000001 # Always on
+A0029524 0800A556
+90029524 1040000C # Default
+A0029524 00000000
+90029524 0800A556 # Always off
+# Fixup canary
+A0029524 00000001
+90029524 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC74 02602021
+D701003C 00000200
+F5029434 0022A530
+F5029436 14400800
+F5029424 BA060000
+F5029426 0C000000
+00000000 FFFF
+00000000 FFFF
+
+[Replay cameras in race]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Makes all replay cameras accessible in race, and allows to switch the cinematic camera by holding R1.
+A401F888 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+C30A92BC 0001 # Replay off
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F888 AEB40008
+# Hold R1 to trigger a cinematic camera
+C30A92BC 0001 # Replay off
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Restore everything when replay is enabled
+A401F888 AEB40008
+C40A92BC 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+
+[True Endurance]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = "Millenium In Rome 2 Hours Endurance" event ends after 2 hours, regardless of how many laps were finished (like in PS2 Gran Turismos).
+# "Help" the game unload segments that normally are left unwritten to,
+# so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A00529DC 801EFB39 # Reset the race overlay for Arcade
+80057054 0000
+A0052A70 000000F6 # Reset the race overlay for Simulation
+80057054 0000
+# Sets 2h Rome Endurance to 255 laps and hides the lap counter
+A4057054 260201C0
+# Set the endurance flag manually for 255 lap races, so replays work properly
+E01D586B 00FF
+E0046F69 0000
+30046F69 0001
+# Time limited race off
+E0046F69 0000
+A602CE24 00020006 # Restore the max laps counter
+# Time limited race on
+C4046F69 0000
+A702CE24 00060002 # Turn off the max laps counter
+# Set laps to 255
+E01D586B 0063
+301D586B 00FF
+00000000 FFFF
+00000000 FFFF
+
+[BGM Switch]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = This patch allows for switching the in-race music by pressing R3. Holding R3 will mute music instead.
+# Check for the R3 key
+D702003C 02000400
+51050005 01
+00000000 FFFF
+# If held for over 60 frames, mute
+52900002 0000003C
+51050005 02
+00000000 FFFF
+# If released before 60 frames passed, switch
+52900002 00000000
+52100005 01
+51050005 03
+00000000 FFFF
+00000000 FFFF
+# Obtain the pointers only if we need it
+51050003 00
+A403EC74 02602021
+52130005 02
+51810003 0002F4F4
+51060304 000002EE
+00000000 FFFF
+00000000 FFFF
+# If the audio pointer is 0, abort (so we don't have to check again)
+52130005 02
+52900003 00000000
+51050005 00
+00000000 FFFF
+00000000 FFFF
+# Switch BGM
+52100005 03
+52150004 05
+51030404 01
+52120004 05
+51050004 00
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+# Unmute
+52100005 03
+52100004 FE
+51050004 00
+00000000 FFFF
+00000000 FFFF
+# Mute
+52100005 02
+52150004 05
+51050004 FE
+00000000 FFFF
+00000000 FFFF
+# Apply changes
+52910003 00000000
+51830303 000002EE
+51040403 00
+51050005 00
+00000000 FFFF
+
+[Fixed Event Generator]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = Improves randomly generated events (One-Make races and Event Generator races) by fixing the course generation.
+A402442C 800229A8
+# new_paramaS -> new_parmaS
+A7023007 6D61616D
+A7023009 53610053
+# Add mini/rev_mini (Autumn Ring Mini) to random events
+A702317C 494C6572
+A702317E 25535F76
+A7023180 3230696D
+A7023182 0064696E
+A7023184 494C0000
+A0050CE8 00000000
+90050CE8 8002317C
+A0050CEC 8002317C
+90050CEC 80023180
+A0050CF0 80023184
+90050CF0 00000000
+00000000 FFFF
+
+[Use 8MB RAM for polygon buffers]
+Type = Gameshark
+Activation = EndFrame
+Author = Silent
+Description = A patch code moving the polygon buffers to the dev RAM area and doubling their size. Required by other patches that make the game render more geometry on screen at once.
+Enable8MBRAM = True
+A401F888 AEB40008
+# Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F88A AEB4
+A7016A6C 000E8020
+D121F88A AEB4
+A7016A70 57000000
+D121F88A AEB4
+A7016A7C 00030007
+D121F88A AEB4
+A7016A78 28210000
+D121F88A AEB4
+A7016A7A 02250000
+D121F88A AEB4
+A7016A88 80000000
+00000000 FFFF


### PR DESCRIPTION
"Ports" over all of @CookiePLMonster Gran Turismo patches from [his website](https://cookieplmonster.github.io/mods/consoles/) with his permission. (Only 21:9 is not included as DuckStation doesn't seem to have it as AR option)

Patches using OverrideCPUOverclock use recommended value for enabling all of them at once as there's no way to know if only one or all are enabled at once.

While making the patches I noticed several bugs in DuckStation that might prevent proper usage

- Patches for games with identical serials display other CRCs patches (same as PCSX2's All CRC display) tricking user that they work, but they don't, The patches themselves are applied correctly, so it's solely Qt GUI not showing only the patches with matching CRC only.
- DuckStation game settings use only serial in their name e.g. SCUS-94488.ini so enabling patch for one serial enables it for all serials of the game.
- If patch is using OverrideCPUOverclock it doesn't spawn the notification warning the user that non-default OC is used.