### PR TITLE
Fix typos in `Tony Hawk's Pro Skater` FPS patches

### DIFF
--- a/patches/SLUS-01419.cht
+++ b/patches/SLUS-01419.cht
@@ -1,5 +1,5 @@
 # Tony Hawk's Pro Skater 3 (USA) SLUS-01419
-[50 FPS]
+[60 FPS]
 Type = Gameshark
 Activation = EndFrame
 Author = PeterDelta

--- a/patches/SLUS-01485.cht
+++ b/patches/SLUS-01485.cht
@@ -1,5 +1,5 @@
 # Tony Hawk's Pro Skater 4 (USA) SLUS-01485
-[50 FPS]
+[60 FPS]
 Type = Gameshark
 Activation = EndFrame
 Author = PeterDelta


### PR DESCRIPTION
The NTSC versions of 3 & 4 run at 60 FPS with the patch.