### PR TITLE
SLUS-01040 - Vagrant Story: Add no teleport cost cheat

### DIFF
--- a/cheats/SLUS-01040.cht
+++ b/cheats/SLUS-01040.cht
@@ -508,6 +508,13 @@ Activation = EndFrame
 D005E1C0 0020
 801FBC84 03E7
 
+[Character\Character Misc.\No Teleport Cost]
+Type = Gameshark
+Activation = EndFrame
+Description = Sets the MP cost for Teleport to 0 for all destinations.
+Author = Anna
+30103F6A A0
+
 [Character\Magic\Warlock\Drain Heart]
 Type = Gameshark
 Activation = EndFrame


### PR DESCRIPTION
Went through the debugger to find the instruction to patch to make teleporting free. Big quality of life patch for me, personally, so I thought I'd contribute it here. This just changes the source register in the instruction that stores teleport costs in memory to the zero register instead of `v0`.