### PR TITLE
NASCAR Rumble (USA) [SLUS-01068] widescreen, draw distance, HQ LOD codes

### DIFF
--- a/patches/SLUS-01068.cht
+++ b/patches/SLUS-01068.cht
@@ -1,0 +1,41 @@
+# NASCAR Rumble (USA) [SLUS-01068]
+[Universal Widescreen]
+Type = Gameshark
+Activation = EndFrame
+Description = Removes geometry culling for any wide aspect ratio resolution. Widescreen Rendering must be enabled.
+Author = Steelmax
+# Bypass frustum check
+# Redirects to $0 register
+80016A82 94A0
+# Increase sub-div chunk tree res
+# Fixes stray triangles
+800634f8 0003
+
+[High Detail LOD]
+Type = Gameshark
+Activation = EndFrame
+Description = Forces the highest texture quality on far objects and cars.
+Author = Steelmax
+80013E84 0000 # Cars
+8006378C 0000 # Textures
+
+[Higher Draw Distance]
+Type = Gameshark
+Activation = EndFrame
+Description = Forces terrain geometry to load at a greater distance.
+Author = Steelmax
+8006464c 0003
+
+[Centered Camera]
+Type = Gameshark
+Activation = EndFrame
+Description = Tilts the camera upward.
+Author = Steelmax
+D00AF8C8 0000
+80016C32 AFA1
+# Reset during replay
+D00AF8C8 0001
+80016C32 AFA2
+# Reset in main menu
+D00BD53C 0001
+80016C32 AFA2


### PR DESCRIPTION
Greetings,
Here's a couple of personal codes for the database. The game is capped at 60fps, on the real HW it varies in the 20-25fps range. A substantial overclock of 400% is required for a stable 60 without these patches, around 450-500% with the entire collection below applied.

Universal Widescreen - works in ANY widescreen aspect ratio; removes the geometry culling derived from 4:3 projection matrix when Widescreen Rendering option is enabled. This does not modify the matrix itself, therefore I'd like an opinion of the maintainers on this one.

High Detail LOD - forces the highest texture LOD.

Higher Draw Distance - increases draw distance which allows highest geometry LODs to render instead of being culled.

Centered Camera - debatable, as this changes the camera angle slightly; I don't feel a perceivable benefit from this for cheating/RetroAch. Perhaps move to cheats or disable RA HC?


No patches:
<img width="2531" height="1904" alt="NASCAR Rumble 2026-03-24-21-09-01" src="https://github.com/user-attachments/assets/d1d5b0e2-bb29-4063-a32c-1625149fc951" />

Widescreen, high LOD textures, higher draw distance applied:
<img width="2531" height="1904" alt="NASCAR Rumble 2026-03-24-21-09-06" src="https://github.com/user-attachments/assets/501948fc-d28a-4caf-8e67-036f6a2394ac" />

The new camera position:
<img width="2531" height="1904" alt="NASCAR Rumble 2026-03-24-21-09-10" src="https://github.com/user-attachments/assets/b59452e6-61cd-4f1a-80c6-1b75b4dec223" />
