### PR TITLE
CI: Bump actions/checkout to v7

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Create cheats archive
         shell: bash
         run: zip -j -r cheats.zip cheats

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -37,7 +37,6 @@ jobs:
         run: |
           INVALID=""
           while IFS= read -r file; do
-            [ -z "$file" ] && continue
             [[ "$file" != *.cht ]] && continue
             if [[ "$file" != cheats/* && "$file" != patches/* ]]; then
               INVALID+="  $file"$'\n'
@@ -59,7 +58,6 @@ jobs:
         run: |
           CHT_FILES=""
           while IFS= read -r file; do
-            [ -z "$file" ] && continue
             if [[ "$file" == *.cht ]]; then
               CHT_FILES+=" $file"
             fi


### PR DESCRIPTION
Fixes Node.js deprecation warning.
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/