### PR TITLE
Ace Combat 2 (USA) [SLUS-00404] persistent camera mode

### DIFF
--- a/patches/SLUS-00404.cht
+++ b/patches/SLUS-00404.cht
@@ -1,0 +1,32 @@
+# Ace Combat 2 (USA) [SLUS-00404]
+[Persistent Camera]
+Type = Gameshark
+Activation = EndFrame
+Description = The last user-selected camera mode now persists across missions.
+Author = Steelmax
+
+# sp = Scratchpad, unoccupied memory
+# m1 = Mission start flag
+# m2 = Mission in progress flag
+# cm = Camera mode: 0x01 - 1st person, 0x02 - 3rd person, 0x00 - inactive
+
+D00B820C 0002 # m1
+D00B8850 0001 # sp
+300B868C 0001 # cm
+
+D00B820C 0002 # m1
+D00B8850 0002 # sp
+300B868C 0002 # cm
+
+# Save user pref
+D00B820C 0001 # m2
+D00B868C 0001 # cm
+300B8850 0001 # sp
+
+D00B820C 0001 # m2
+D00B868C 0002 # cm
+300B8850 0002 # sp
+
+# Demo/attract fix
+D00B7D14 0005
+D00B868C 0000 # cm


### PR DESCRIPTION
A simple QoL patch for an annoying problem. The game does not let the player choose 1st/3rd person camera in the game settings; as a result, it defaults to 1st person view whenever a new mission starts, forcing the player to switch modes if they wish to play in the 3rd person.
This patch uses a free memory region adjacent to HUD render data to store the last selected camera option chosen by the player.

There is another version of this patch as a "cheat" with Options/?? variables. It lets users preselect either 1st or 3rd-person camera modes as the game's default, but it is, alas, unavailable in regular patches (saddens me).