### PR TITLE
Fix minor opcode mistake in SLUS-00404.cht

### DIFF
--- a/patches/SLUS-00404.cht
+++ b/patches/SLUS-00404.cht
@@ -29,4 +29,4 @@ D00B868C 0002 # cm
 
 # Demo/attract fix
 D00B7D14 0005
-D00B868C 0000 # cm
+300B868C 0000 # cm


### PR DESCRIPTION
Follow-up to #71.

Fixes a minor opcode issue at line 32, where it was supposed to be a constant write, not an if-equal check.
Retested in-game to confirm working and this oversight has been fixed.